### PR TITLE
fix: extract discoverOrganonFiles, fix root-path false positives

### DIFF
--- a/packages/tools/src/core/discover.test.ts
+++ b/packages/tools/src/core/discover.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for shared organon file discovery.
+ *
+ * @organon-invariant INV-TOOLS-2 every-command-has-tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import { discoverOrganonFiles } from './discover.js';
+import { MemoryFileSystem } from './test-helpers.js';
+import type { OrganonConfig } from './types.js';
+
+function makeConfig(overrides?: Partial<OrganonConfig>): OrganonConfig {
+  return {
+    projectRoot: '/project',
+    organonPaths: ['.', 'organon'],
+    organonGlobs: ['**/ETHOS.md', '**/PHILOSOPHY.md', '**/README.md'],
+    ignorePatterns: [],
+    workflowPaths: {},
+    freshnessThresholdHours: 24,
+    ...overrides,
+  };
+}
+
+describe('discoverOrganonFiles', () => {
+  it('discovers files in named organon paths recursively', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/organon/ETHOS.md': 'ethos',
+      '/project/organon/domains/tools/ETHOS.md': 'ethos nested',
+      '/project/organon/domains/tools/PHILOSOPHY.md': 'philosophy nested',
+    });
+    const config = makeConfig({ organonPaths: ['organon'] });
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toEqual([
+      'organon/ETHOS.md',
+      'organon/domains/tools/ETHOS.md',
+      'organon/domains/tools/PHILOSOPHY.md',
+    ]);
+  });
+
+  it('discovers root-level files via "." path', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/ETHOS.md': 'root ethos',
+      '/project/README.md': 'root readme',
+    });
+    const config = makeConfig({ organonPaths: ['.'] });
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toContain('ETHOS.md');
+    expect(result).toContain('README.md');
+  });
+
+  it('does NOT discover nested files via "." path (the fix)', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/README.md': 'root readme — organon file',
+      '/project/ETHOS.md': 'root ethos — organon file',
+      '/project/experiments/001/README.md': 'experiment readme — NOT organon',
+      '/project/modules/app/README.md': 'module readme — NOT organon',
+      '/project/research/README.md': 'research readme — NOT organon',
+    });
+    const config = makeConfig({ organonPaths: ['.'] });
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toContain('README.md');
+    expect(result).toContain('ETHOS.md');
+    expect(result).not.toContain('experiments/001/README.md');
+    expect(result).not.toContain('modules/app/README.md');
+    expect(result).not.toContain('research/README.md');
+  });
+
+  it('combines "." root-only with named path recursive discovery', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/README.md': 'root readme',
+      '/project/ETHOS.md': 'root ethos',
+      '/project/experiments/README.md': 'should be excluded',
+      '/project/organon/ETHOS.md': 'organon ethos',
+      '/project/organon/domains/tools/ETHOS.md': 'nested organon ethos',
+    });
+    const config = makeConfig({ organonPaths: ['.', 'organon'] });
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toEqual([
+      'ETHOS.md',
+      'README.md',
+      'organon/ETHOS.md',
+      'organon/domains/tools/ETHOS.md',
+    ]);
+  });
+
+  it('applies ignorePatterns', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/organon/ETHOS.md': 'ethos',
+      '/project/organon/vendor/ETHOS.md': 'vendor ethos',
+    });
+    const config = makeConfig({
+      organonPaths: ['organon'],
+      ignorePatterns: ['**/vendor/**'],
+    });
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toEqual(['organon/ETHOS.md']);
+    expect(result).not.toContain('organon/vendor/ETHOS.md');
+  });
+
+  it('deduplicates files matched by multiple paths', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/organon/ETHOS.md': 'ethos',
+    });
+    // Both paths could match the same file
+    const config = makeConfig({
+      organonPaths: ['organon', 'organon'],
+    });
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toEqual(['organon/ETHOS.md']);
+  });
+
+  it('returns sorted results', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/organon/domains/z/ETHOS.md': 'z',
+      '/project/organon/domains/a/ETHOS.md': 'a',
+      '/project/organon/ETHOS.md': 'root',
+    });
+    const config = makeConfig({ organonPaths: ['organon'] });
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toEqual([
+      'organon/ETHOS.md',
+      'organon/domains/a/ETHOS.md',
+      'organon/domains/z/ETHOS.md',
+    ]);
+  });
+
+  it('returns empty array when no files match', async () => {
+    const fs = new MemoryFileSystem({});
+    const config = makeConfig();
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toEqual([]);
+  });
+
+  it('handles globs without **/ prefix via "." path unchanged', async () => {
+    // A glob like "ETHOS.md" (no **/ prefix) should work as-is
+    const fs = new MemoryFileSystem({
+      '/project/ETHOS.md': 'ethos',
+    });
+    const config = makeConfig({
+      organonPaths: ['.'],
+      organonGlobs: ['ETHOS.md'],
+    });
+    const result = await discoverOrganonFiles('/project', config, fs);
+
+    expect(result).toEqual(['ETHOS.md']);
+  });
+});

--- a/packages/tools/src/core/discover.ts
+++ b/packages/tools/src/core/discover.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared organon file discovery.
+ *
+ * Resolves organonPaths × organonGlobs into a deduplicated, sorted list of
+ * organon file paths.  When the organon path is "." (project root),
+ * recursive glob prefixes are stripped so that only root-level files match — this
+ * prevents false-positive frontmatter checks on non-organon markdown files
+ * buried deeper in the project tree.
+ */
+
+import type { FileSystem, OrganonConfig } from './types.js';
+
+export async function discoverOrganonFiles(
+  projectRoot: string,
+  config: OrganonConfig,
+  fs: FileSystem,
+): Promise<string[]> {
+  const allFiles = new Set<string>();
+
+  for (const organonPath of config.organonPaths) {
+    for (const pattern of config.organonGlobs) {
+      // "." means project root — match root-level files only (no recursion).
+      // Named paths like "organon" or "book-llms" keep recursive ** globs.
+      const fullPattern = organonPath === '.'
+        ? pattern.replace(/^\*\*\//, '')
+        : `${organonPath}/${pattern}`;
+      const matches = await fs.glob(fullPattern, {
+        cwd: projectRoot,
+        ignore: config.ignorePatterns,
+      });
+      for (const m of matches) {
+        allFiles.add(m);
+      }
+    }
+  }
+
+  return [...allFiles].sort();
+}

--- a/packages/tools/src/core/find.test.ts
+++ b/packages/tools/src/core/find.test.ts
@@ -6,7 +6,7 @@ import type { OrganonConfig } from './types.js';
 function makeConfig(projectRoot: string): OrganonConfig {
   return {
     projectRoot,
-    organonPaths: ['.'],
+    organonPaths: ['.', 'organon'],
     organonGlobs: ['**/ETHOS.md', '**/README.md'],
     ignorePatterns: [],
     workflowPaths: {},

--- a/packages/tools/src/core/find.ts
+++ b/packages/tools/src/core/find.ts
@@ -14,6 +14,7 @@
 
 import { parseFrontmatter, parseOrganonFile } from './frontmatter-parser.js';
 import { joinPath, dirName } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   DiagnosticMessage,
   FileSystem,
@@ -216,27 +217,4 @@ function findByName(name: string, parsed: ParsedOrganonFile[]): FindMatch[] {
 function isRootFile(path: string): boolean {
   const normalized = path.replace(/\\/g, '/');
   return !normalized.includes('/') || normalized.split('/').length <= 2;
-}
-
-async function discoverOrganonFiles(
-  projectRoot: string,
-  config: OrganonConfig,
-  fs: FileSystem,
-): Promise<string[]> {
-  const allFiles = new Set<string>();
-
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const m of matches) {
-        allFiles.add(m);
-      }
-    }
-  }
-
-  return [...allFiles].sort();
 }

--- a/packages/tools/src/core/generate-tests.ts
+++ b/packages/tools/src/core/generate-tests.ts
@@ -8,6 +8,7 @@
 
 import { parseFrontmatter } from './frontmatter-parser.js';
 import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import {
   extractInvariants,
   scanTestAnnotations,
@@ -200,31 +201,20 @@ export async function generateTests(
   const { projectRoot, config, fs, invariantIds } = options;
 
   // 1. Discover organon files and extract invariants
-  const seenPaths = new Set<string>();
+  const discoveredFiles = await discoverOrganonFiles(projectRoot, config, fs);
   const parsedFiles: Array<{
     path: string;
     frontmatter: { type?: string; invariants?: InvariantEntry[] } | null;
   }> = [];
 
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const file of matches) {
-        if (seenPaths.has(file)) continue;
-        seenPaths.add(file);
-        const absPath = joinPath(projectRoot, file);
-        try {
-          const content = await fs.readFile(absPath);
-          const { frontmatter } = parseFrontmatter(content);
-          parsedFiles.push({ path: file, frontmatter });
-        } catch {
-          // Skip unreadable files
-        }
-      }
+  for (const file of discoveredFiles) {
+    const absPath = joinPath(projectRoot, file);
+    try {
+      const content = await fs.readFile(absPath);
+      const { frontmatter } = parseFrontmatter(content);
+      parsedFiles.push({ path: file, frontmatter });
+    } catch {
+      // Skip unreadable files
     }
   }
 

--- a/packages/tools/src/core/health.ts
+++ b/packages/tools/src/core/health.ts
@@ -9,6 +9,7 @@ import { parseFrontmatter, estimateTokens, parseOrganonFile } from './frontmatte
 import { validateFrontmatter } from './validate-frontmatter.js';
 import { verifyPlaceholders } from './verify-placeholders.js';
 import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   DiagnosticMessage,
   FileSystem,
@@ -176,31 +177,4 @@ export async function health(options: HealthOptions): Promise<HealthResult> {
     errors,
     warnings,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-async function discoverOrganonFiles(
-  projectRoot: string,
-  config: OrganonConfig,
-  fs: FileSystem,
-): Promise<string[]> {
-  const allFiles = new Set<string>();
-
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const m of matches) {
-        allFiles.add(m);
-      }
-    }
-  }
-
-  return [...allFiles].sort();
 }

--- a/packages/tools/src/core/invariant-coverage.ts
+++ b/packages/tools/src/core/invariant-coverage.ts
@@ -9,6 +9,7 @@
 
 import { parseFrontmatter } from './frontmatter-parser.js';
 import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   DiagnosticMessage,
   FileSystem,
@@ -189,29 +190,18 @@ export async function computeInvariantCoverage(options: {
 }): Promise<InvariantCoverageResult> {
   const { projectRoot, config, fs: fileSystem } = options;
 
-  // Discover organon files and parse frontmatter (deduplicate by path)
-  const seenPaths = new Set<string>();
+  // Discover organon files and parse frontmatter
+  const files = await discoverOrganonFiles(projectRoot, config, fileSystem);
   const parsedFiles: Array<{ path: string; frontmatter: { type?: string; invariants?: InvariantEntry[] } | null }> = [];
 
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fileSystem.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const file of matches) {
-        if (seenPaths.has(file)) continue;
-        seenPaths.add(file);
-        const absPath = joinPath(projectRoot, file);
-        try {
-          const content = await fileSystem.readFile(absPath);
-          const { frontmatter } = parseFrontmatter(content);
-          parsedFiles.push({ path: file, frontmatter });
-        } catch {
-          // Skip unreadable files
-        }
-      }
+  for (const file of files) {
+    const absPath = joinPath(projectRoot, file);
+    try {
+      const content = await fileSystem.readFile(absPath);
+      const { frontmatter } = parseFrontmatter(content);
+      parsedFiles.push({ path: file, frontmatter });
+    } catch {
+      // Skip unreadable files
     }
   }
 

--- a/packages/tools/src/core/query.test.ts
+++ b/packages/tools/src/core/query.test.ts
@@ -6,7 +6,7 @@ import type { OrganonConfig } from './types.js';
 function makeConfig(projectRoot: string): OrganonConfig {
   return {
     projectRoot,
-    organonPaths: ['.'],
+    organonPaths: ['.', 'organon'],
     organonGlobs: ['**/ETHOS.md', '**/PHILOSOPHY.md', '**/PROTOCOLS.md', '**/README.md'],
     ignorePatterns: [],
     workflowPaths: {},

--- a/packages/tools/src/core/query.ts
+++ b/packages/tools/src/core/query.ts
@@ -8,6 +8,7 @@
 
 import { parseFrontmatter, parseOrganonFile } from './frontmatter-parser.js';
 import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   DiagnosticMessage,
   FileSystem,
@@ -183,31 +184,4 @@ export async function query(options: QueryOptions): Promise<QueryResult> {
     errors,
     warnings,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-async function discoverOrganonFiles(
-  projectRoot: string,
-  config: OrganonConfig,
-  fs: FileSystem,
-): Promise<string[]> {
-  const allFiles = new Set<string>();
-
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const m of matches) {
-        allFiles.add(m);
-      }
-    }
-  }
-
-  return [...allFiles].sort();
 }

--- a/packages/tools/src/core/suggest-tools.ts
+++ b/packages/tools/src/core/suggest-tools.ts
@@ -8,6 +8,7 @@
 
 import { parseFrontmatter } from './frontmatter-parser.js';
 import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   AutomationTier,
   Complexity,
@@ -174,31 +175,4 @@ function buildReason(
   return reasons.length > 0
     ? `Upgrade ${currentTier} → ${suggestedTier}: ${reasons.join(', ')}`
     : `Consider upgrading from ${currentTier} to ${suggestedTier}`;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-async function discoverOrganonFiles(
-  projectRoot: string,
-  config: OrganonConfig,
-  fs: FileSystem,
-): Promise<string[]> {
-  const allFiles = new Set<string>();
-
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const m of matches) {
-        allFiles.add(m);
-      }
-    }
-  }
-
-  return [...allFiles].sort();
 }

--- a/packages/tools/src/core/validate-frontmatter.ts
+++ b/packages/tools/src/core/validate-frontmatter.ts
@@ -9,6 +9,7 @@
 
 import { parseFrontmatter, estimateTokens, extractSection, countSectionEntries, countTableRows } from './frontmatter-parser.js';
 import { joinPath, baseName, dirName } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   DiagnosticMessage,
   FileSystem,
@@ -623,25 +624,3 @@ function inferScopeFromPath(path: string): FrontmatterScope | null {
   return null;
 }
 
-async function discoverOrganonFiles(
-  projectRoot: string,
-  config: OrganonConfig,
-  fs: FileSystem,
-): Promise<string[]> {
-  const allFiles = new Set<string>();
-
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const m of matches) {
-        allFiles.add(m);
-      }
-    }
-  }
-
-  return [...allFiles].sort();
-}

--- a/packages/tools/src/core/verify-placeholders.ts
+++ b/packages/tools/src/core/verify-placeholders.ts
@@ -8,6 +8,7 @@
  */
 
 import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   DiagnosticMessage,
   FileSystem,
@@ -93,31 +94,4 @@ export async function verifyPlaceholders(options: {
     errors,
     warnings,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-async function discoverOrganonFiles(
-  projectRoot: string,
-  config: OrganonConfig,
-  fs: FileSystem,
-): Promise<string[]> {
-  const allFiles = new Set<string>();
-
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const m of matches) {
-        allFiles.add(m);
-      }
-    }
-  }
-
-  return [...allFiles].sort();
 }

--- a/packages/tools/src/core/verify-references.test.ts
+++ b/packages/tools/src/core/verify-references.test.ts
@@ -9,10 +9,10 @@ import { verifyReferences } from './verify-references.js';
 import { MemoryFileSystem, makeEthos, makeWorkflow } from './test-helpers.js';
 import type { OrganonConfig } from './types.js';
 
-function makeConfig(projectRoot: string): OrganonConfig {
+function makeConfig(projectRoot: string, extraPaths: string[] = []): OrganonConfig {
   return {
     projectRoot,
-    organonPaths: ['.'],
+    organonPaths: ['.', ...extraPaths],
     organonGlobs: ['**/ETHOS.md', '**/PHILOSOPHY.md', '**/README.md'],
     ignorePatterns: [],
     workflowPaths: { generic: 'workflows' },
@@ -28,7 +28,7 @@ describe('verifyReferences', () => {
       '/project/ETHOS.md': parentEthos,
       '/project/domains/child/ETHOS.md': childEthos,
     });
-    const config = makeConfig('/project');
+    const config = makeConfig('/project', ['domains']);
     const result = await verifyReferences({ projectRoot: '/project', config, fs });
     expect(result.success).toBe(true);
   });

--- a/packages/tools/src/core/verify-references.ts
+++ b/packages/tools/src/core/verify-references.ts
@@ -12,6 +12,7 @@
 
 import { parseFrontmatter } from './frontmatter-parser.js';
 import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   DiagnosticMessage,
   FileSystem,
@@ -166,25 +167,6 @@ export async function verifyReferences(options: {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-async function discoverOrganonFiles(
-  projectRoot: string,
-  config: OrganonConfig,
-  fs: FileSystem,
-): Promise<string[]> {
-  const allFiles = new Set<string>();
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const m of matches) allFiles.add(m);
-    }
-  }
-  return [...allFiles].sort();
-}
 
 async function discoverWorkflowFiles(
   projectRoot: string,

--- a/packages/tools/src/core/verify-triplets.ts
+++ b/packages/tools/src/core/verify-triplets.ts
@@ -10,6 +10,7 @@
 
 import { parseFrontmatter } from './frontmatter-parser.js';
 import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
 import type {
   AutomationTier,
   DiagnosticMessage,
@@ -244,25 +245,3 @@ async function discoverWorkflowFiles(
   return [...files].sort();
 }
 
-async function discoverOrganonFiles(
-  projectRoot: string,
-  config: OrganonConfig,
-  fs: FileSystem,
-): Promise<string[]> {
-  const allFiles = new Set<string>();
-
-  for (const organonPath of config.organonPaths) {
-    for (const pattern of config.organonGlobs) {
-      const fullPattern = organonPath === '.' ? pattern : `${organonPath}/${pattern}`;
-      const matches = await fs.glob(fullPattern, {
-        cwd: projectRoot,
-        ignore: config.ignorePatterns,
-      });
-      for (const m of matches) {
-        allFiles.add(m);
-      }
-    }
-  }
-
-  return [...allFiles].sort();
-}


### PR DESCRIPTION
## Summary

- **Extracts `discoverOrganonFiles`** from 10 copy-pasted copies into a single shared module at `packages/tools/src/core/discover.ts`
- **Fixes false-positive frontmatter checks** on non-organon markdown files (e.g., `experiments/README.md`, `modules/app/README.md`) when `organonPaths` includes `"."` (project root)
- Root cause: when `organonPath` is `"."`, glob patterns like `**/README.md` recursively matched the entire project tree. Fix strips `**/` prefix for root path so only root-level files match.

| File Location | Before | After |
|--------------|--------|-------|
| `README.md` (root) | Checked | Checked |
| `organon/**/ETHOS.md` | Checked | Checked |
| `experiments/foo/README.md` | **Checked (false positive)** | **Skipped** |
| `modules/bar/README.md` | **Checked (false positive)** | **Skipped** |

## Test plan

- [x] New `discover.test.ts` with 9 test cases (recursive, root-only, the fix, ignorePatterns, dedup, sorting, edge cases)
- [x] Updated `find.test.ts`, `query.test.ts`, `verify-references.test.ts` configs to use explicit organon paths
- [x] All 261 tools tests pass, all 206 testing package tests pass (467 total)
- [x] `organon verify` — all 9 gates pass
- [x] `organon health` — 95/100 (unchanged from baseline)
- [x] Cleaned up 4 empty `// Helpers` sections left behind by function removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)