### PR TITLE
feat: RFC 009 — epistemic model & knowledge interoperability

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ organon query                   # Query frontmatter across files
 organon coverage                # Invariant test coverage report
 organon generate-tests          # Scaffold tier-4 invariant tests
 organon suggest                 # Suggest automation tier upgrades
+organon export                  # Export knowledge graph as JSON
 organon release <bump>          # Version bump, tag, and release
 organon mcp                     # Start MCP server (IDE integration)
 ```

--- a/book-llms/frontmatter-system.md
+++ b/book-llms/frontmatter-system.md
@@ -2,9 +2,9 @@
 type: rationale
 scope: meta
 name: frontmatter-system
-version: "1.0"
+version: "1.1"
 summary: YAML frontmatter specification for progressive disclosure — the mechanism that makes token-efficient big organons possible
-token_estimate: 4124
+token_estimate: 4500
 inherits_from: [meta-organon]
 load_priority: high
 required_for:
@@ -126,6 +126,23 @@ related_files: string[]       # File paths this RFC impacts or references
 ```
 
 RFCs are rationale files with lifecycle tracking. The `status` field is the most important for progressive disclosure — an implementer agent scanning RFC frontmatter can skip `implemented` or `withdrawn` RFCs immediately. Use `related_files` to list impacted organon and code files so agents can trace RFC→file relationships without loading the full RFC.
+
+### Observations (`type: rationale`, path in `observations/`)
+
+```yaml
+status: string                # signal | pattern | actionable | resolved
+created: string               # ISO 8601 date
+author: string                # Author name or agent identifier
+```
+
+Observations are rationale files capturing empirical learnings from work sessions. The `status` field tracks lifecycle maturity:
+
+- **signal** — Initial observation, single instance, may not recur
+- **pattern** — Observed multiple times, emerging trend
+- **actionable** — Clear enough to drive a change (RFC, heuristic, tool improvement)
+- **resolved** — Graduated into the methodology (became an RFC, invariant, or heuristic)
+
+The `status` field is optional — existing observations without it remain valid. Agents can use it to filter: skip `resolved` observations (already incorporated), prioritize `actionable` ones.
 
 ### PROTOCOL.md (`type: procedures`)
 

--- a/book-llms/patterns.md
+++ b/book-llms/patterns.md
@@ -2,9 +2,9 @@
 type: rationale
 scope: meta
 name: patterns
-version: "1.0"
+version: "1.1"
 summary: Common patterns and anti-patterns — progressive disclosure, enforcement loop, code mapping, verification, onboarding, and more
-token_estimate: 15700
+token_estimate: 15800
 pattern_count: 23
 inherits_from: [meta-organon]
 load_priority: medium
@@ -1081,7 +1081,8 @@ The Four-Step Loop is the **operational rhythm**. The Enforcement Loop is the **
 - **Directory:** `organon/observations/NNN-descriptive-name.md` at project level
 - **Frontmatter:** `type: rationale` (no new artifact type — observations are empirical rationale)
 - **Required sections:** Context, Observations (O1..ON with Signal/Implication/Suggested Action), Patterns to Watch
-- **Mental model:** Signal (noticed once) → Pattern (confirmed across sessions) → Actionable (root cause understood, clear fix)
+- **Mental model:** Signal (noticed once) → Pattern (confirmed across sessions) → Actionable (root cause understood, clear fix) → Resolved (graduated into methodology)
+- **Frontmatter status field:** `status: signal | pattern | actionable | resolved` tracks this lifecycle
 
 ### When to record
 

--- a/book-llms/templates.md
+++ b/book-llms/templates.md
@@ -2,9 +2,9 @@
 type: rationale
 scope: meta
 name: templates
-version: "1.0"
-summary: Copy-paste templates for ETHOS, PHILOSOPHY, PROTOCOL, and WORKFLOW files — all with frontmatter and standardized sections
-token_estimate: 6200
+version: "1.1"
+summary: Copy-paste templates for ETHOS, PHILOSOPHY, PROTOCOL, WORKFLOW, Observation, and RFC files — all with frontmatter and standardized sections
+token_estimate: 7200
 inherits_from: [meta-organon]
 load_priority: medium
 required_for:
@@ -577,6 +577,65 @@ Feature-specific checks (caching invariants):
 - [ ] TTL is set and ≤ 24 hours
 - [ ] Cache miss path works identically to non-cached path
 ```
+
+---
+
+## Observation Template
+
+Observations capture empirical learnings from work sessions. They live in `organon/observations/` and use `type: rationale` (no new artifact type — observations are empirical rationale). The `status` field tracks lifecycle maturity: signal → pattern → actionable → resolved.
+
+```markdown
+---
+type: rationale
+scope: [product|domain|feature|methodology]
+name: [descriptive-name]
+version: "1.0"
+summary: [One-sentence description of what was observed]
+token_estimate: [estimate]
+status: signal
+created: [YYYY-MM-DD]
+author: [author-name]
+audience: [llm, human]
+---
+
+# Observation NNN: [Descriptive Title]
+
+> [One-sentence summary of the key learning]
+
+---
+
+## Context
+
+[What work was being done when this was observed? What prompted the observation?]
+
+## Observations
+
+### O1: [First observation title]
+
+- **Signal:** [What was noticed]
+- **Implication:** [Why it matters]
+- **Suggested Action:** [What could be done about it]
+
+### O2: [Second observation title]
+
+- **Signal:** [What was noticed]
+- **Implication:** [Why it matters]
+- **Suggested Action:** [What could be done about it]
+
+## Patterns to Watch
+
+- [Pattern that may emerge if this recurs]
+- [Related area to monitor]
+```
+
+**Status lifecycle:**
+
+| Status | Meaning | Next step |
+|--------|---------|-----------|
+| `signal` | Noticed once, may not recur | Watch for recurrence |
+| `pattern` | Confirmed across multiple sessions | Investigate root cause |
+| `actionable` | Root cause understood, clear fix | Create RFC or heuristic |
+| `resolved` | Graduated into methodology | Link to resulting change |
 
 ---
 

--- a/book-llms/three-layer-architecture.md
+++ b/book-llms/three-layer-architecture.md
@@ -2,9 +2,9 @@
 type: rationale
 scope: meta
 name: three-layer-architecture
-version: "1.2"
-summary: The enforcement loop — protocols, workflows, tools, and verification (tiered testing, drift detection, violation handling) bind organons to LLM execution
-token_estimate: 10800
+version: "1.3"
+summary: The enforcement loop — protocols, workflows, tools, verification, and epistemic categories bind organons to LLM execution and external knowledge systems
+token_estimate: 12200
 inherits_from: [meta-organon]
 load_priority: high
 required_for:
@@ -429,6 +429,63 @@ The LLM is the **runtime** that executes the enforcement loop. It is the interfa
 The human's job is to **define** (write organons) and **review** (approve results). The LLM's job is to **execute** (follow workflows, invoke tools) and **report** (surface verification results). The tools' job is to **enforce** (check invariants, validate references, gate merges).
 
 This is what makes Organon **LLM-centric**: the methodology is designed to be consumed and executed by LLMs, with humans as authors and reviewers, not as the execution engine.
+
+---
+
+## Epistemic Categories
+
+Organon files implicitly encode three epistemic categories — types of knowledge that serve different purposes in the enforcement loop. Making these explicit enables interoperability with external knowledge systems and provides an alternative query lens on existing data.
+
+### The three categories
+
+| Category | Definition | What it captures | Organon mapping |
+|----------|-----------|-----------------|-----------------|
+| **Constraint** | Normative declaration — what *should* be true | Design intent, architectural boundaries, behavioral limits | ETHOS.md invariants (`type: constraints`) |
+| **Assertion** | Descriptive claim — what *is* empirically observed | Session learnings, measured outcomes, discovered patterns | Observation files (`type: rationale`, path in `observations/`) |
+| **Rule** | Enforcement logic — what *must* hold, checked automatically | Verification gates, protocol steps, CI checks | PROTOCOL.md procedures (`type: procedures`) |
+
+**These are not new artifact types.** They are an epistemic lens on existing artifacts. An ETHOS.md file is still `type: constraints` — but its epistemic category is "constraint." An observation file is still `type: rationale` — but its epistemic category is "assertion."
+
+### Lifecycle through the enforcement loop
+
+Each category maps to specific phases of the enforcement loop:
+
+```
+Category        Primary loop phase      How it enters the loop
+─────────────   ──────────────────      ──────────────────────
+Constraint      DEFINE                  Human writes ETHOS.md invariant
+Assertion       COMPOUND                Agent captures observation during work
+Rule            VERIFY                  Gate checks constraint against code
+```
+
+**Constraints** are created in DEFINE and consumed in VERIFY (gates check whether code satisfies them). **Assertions** are created in COMPOUND (session learnings) and consumed in EVOLVE (when they mature into new constraints or heuristics). **Rules** are created alongside tools in the BIND/EXECUTE phases and operate in VERIFY.
+
+### Knowledge interoperability
+
+The `organon export` command produces a structured JSON representation classified by epistemic category. This is the interoperability surface — external knowledge systems consume this instead of parsing organon files directly.
+
+**Export format:**
+
+```json
+{
+  "version": "0.4.1",
+  "exported_at": "2026-02-15T...",
+  "entities": [
+    { "id": "organon:domains/tools/ETHOS", "kind": "organon-file", "name": "tools", "scope": "domain", "type": "constraints", "category": "constraint" }
+  ],
+  "assertions": [
+    { "id": "inv:INV-TOOLS-1", "category": "constraint", "source": "organon/domains/tools/ETHOS.md", "predicate": "declares_invariant", "content": "..." }
+  ],
+  "relationships": [
+    { "source": "organon:domains/tools/ETHOS", "predicate": "inherits_from", "target": "organon:ETHOS" }
+  ],
+  "rules": [
+    { "id": "gate:frontmatter", "predicate": "validates", "targets": ["all organon files"], "type": "blocking" }
+  ]
+}
+```
+
+**Design principle:** The export format is a projection, not a database. It contains enough structure for external tools to build their own indexes, but organon files remain the source of truth. Re-exporting always produces a fresh snapshot.
 
 ---
 

--- a/docs/03-cli-reference.md
+++ b/docs/03-cli-reference.md
@@ -20,6 +20,7 @@ Complete reference for the `organon` CLI. All commands share common global optio
 - [Coverage Commands](#coverage-commands)
   - [coverage](#coverage)
 - [Integration Commands](#integration-commands)
+  - [export](#export)
   - [mcp](#mcp)
 - [Configuration](#configuration)
 
@@ -262,6 +263,38 @@ organon coverage --json           # Machine-readable JSON output
 
 ## Integration Commands
 
+### export
+
+Export the organon knowledge graph as structured JSON, classified by epistemic category. Produces entities, assertions, relationships, and rules for consumption by external knowledge systems.
+
+```bash
+organon export                  # Pretty-printed JSON to stdout
+organon export --no-pretty      # Compact JSON (for piping)
+```
+
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--pretty` | boolean | `true` | Pretty-print JSON output |
+
+**Output format:**
+
+```json
+{
+  "version": "0.4.1",
+  "exported_at": "2026-02-15T...",
+  "entities": [{ "id": "organon:...", "kind": "organon-file", "category": "constraint" }],
+  "assertions": [{ "id": "inv:INV-...", "category": "constraint", "predicate": "declares_invariant" }],
+  "relationships": [{ "source": "organon:...", "predicate": "inherits_from", "target": "organon:..." }],
+  "rules": [{ "id": "gate:frontmatter", "predicate": "validates", "type": "blocking" }]
+}
+```
+
+**Exit codes:** `0` on success, `1` on error.
+
+---
+
 ### mcp
 
 Start the Organon MCP (Model Context Protocol) server on stdio transport. Enables IDE integration.
@@ -275,7 +308,7 @@ organon mcp --project-root .     # Explicit project root
 
 | Type | Count | Examples |
 |------|-------|---------|
-| Tools | 8 | `organon_validate_frontmatter`, `organon_verify`, `organon_health`, `organon_find`, `organon_query`, `organon_generate_frontmatter`, `organon_verify_triplets`, `organon_suggest_tools` |
+| Tools | 9 | `organon_validate_frontmatter`, `organon_verify`, `organon_health`, `organon_find`, `organon_query`, `organon_generate_frontmatter`, `organon_verify_triplets`, `organon_suggest_tools`, `organon_export` |
 | Resources | 4 | `organon://index`, `organon://file/{path}`, `organon://scope/{scope}`, `organon://health` |
 | Prompts | 4 | `implement-feature`, `review-changes`, `create-organon`, `evolve-organon` |
 

--- a/organon.config.json
+++ b/organon.config.json
@@ -11,7 +11,9 @@
     "**/PROTOCOL.md",
     "**/PROTOCOLS.md",
     "**/README.md",
-    "**/components.md"
+    "**/components.md",
+    "**/observations/*.md",
+    "**/rfcs/*.md"
   ],
   "ignorePatterns": [
     "**/node_modules/**",

--- a/organon/domains/tools/ETHOS.md
+++ b/organon/domains/tools/ETHOS.md
@@ -41,7 +41,7 @@ audience: [llm, human]
 ### What Organon Tools IS
 
 - A TypeScript/Node.js CLI for enforcing Organon methodology
-- Command-based architecture using yargs (init, upgrade, generate, validate, verify, coverage, find, query, health)
+- Command-based architecture using yargs (14 commands: init, upgrade, generate, validate, verify, coverage, find, query, health, generate-tests, suggest, export, release, mcp)
 - Project bootstrapping (init) and incremental upgrade (upgrade) for methodology adoption
 - Implementation of verification gates from three-layer-architecture.md
 - Frontmatter generator and validator matching book-llms/ schema exactly

--- a/organon/observations/005-epistemic-export-gaps.md
+++ b/organon/observations/005-epistemic-export-gaps.md
@@ -1,0 +1,43 @@
+---
+type: rationale
+scope: product
+name: epistemic-export-gaps
+version: "1.0"
+summary: Observations from implementing RFC 009 (epistemic model) — discovery gaps for non-standard organon files and methodology-spec-evolution value confirmation
+token_estimate: 600
+status: resolved
+created: "2026-02-15"
+author: Claude Opus 4.6
+audience: [llm, human]
+---
+
+# Observation 005: Epistemic Export Gaps
+
+> What we learned implementing the epistemic model: observations and RFCs were invisible to tooling until glob patterns were expanded.
+
+---
+
+## Context
+
+RFC 009 added `organon export` and `organon query --category`. During testing, `--category assertion` returned zero results despite 4 observation files existing with valid frontmatter. Root cause: `organonGlobs` only matched standard file names (ETHOS.md, PHILOSOPHY.md, etc.), not numbered observation/RFC files.
+
+---
+
+## Observations
+
+### O1: Observation files not in default discovery globs
+
+- **Signal:** `organon query --category assertion` returned 0 results. Observation files exist at `organon/observations/001-*.md` but aren't named ETHOS.md/PHILOSOPHY.md/etc.
+- **Implication:** Any feature that depends on discovering all organon files (export, category filter, health) silently ignores observations and RFCs. The progressive disclosure model breaks — you can't disclose what you can't discover.
+- **Suggested Action:** Add `**/observations/*.md` and `**/rfcs/*.md` to both `DEFAULT_ORGANON_GLOBS` and `organon.config.json`.
+
+### O2: Methodology-spec-evolution skill catches real drift
+
+- **Signal:** Running the skill after implementation found two genuine issues: templates.md lacked an Observation template, and patterns.md used "evolved" instead of "resolved" for the terminal lifecycle state.
+- **Implication:** The skill's propagation checklist is genuinely valuable, not ceremony. These would have been silent inconsistencies without it.
+- **Suggested Action:** None needed — this confirms the skill's value. Continue using it after book-llms/ changes.
+
+## Patterns to Watch
+
+- After adding new organon file conventions (like observations), check that discovery globs cover them
+- The `organon init` templates should include observation/RFC globs in generated `organon.config.json`

--- a/organon/observations/README.md
+++ b/organon/observations/README.md
@@ -32,6 +32,7 @@ See [RFC 005](../../rfcs/005-observation-synthesis-loop.md) for the convention s
 | [002](./002-rfc-005-implementation.md) | RFC 005 Implementation Observations | 2026-02-12 | Complete |
 | [003](./003-v040-onboarding-dogfood.md) | v0.4.0 Onboarding Dogfood | 2026-02-13 | Complete |
 | [004](./004-scala-publishing-friction.md) | Scala Publishing Friction | 2026-02-15 | Complete |
+| [005](./005-epistemic-export-gaps.md) | Epistemic Export Gaps | 2026-02-15 | Resolved |
 
 ---
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -42,10 +42,10 @@ packages/tools/src/
 │   ├── suggest-tools.ts    ← Automation tier suggestions
 │   └── verify.ts       ← Gate registry orchestrator
 ├── cli/                ← Thin yargs adapter
-│   └── commands/       ← validate, generate, query, health, find, verify, mcp
+│   └── commands/       ← validate, generate, query, health, find, verify, export, mcp
 ├── mcp/                ← Thin MCP adapter
 │   ├── server.ts       ← stdio transport
-│   ├── tools.ts        ← 8 MCP tools
+│   ├── tools.ts        ← 9 MCP tools
 │   ├── resources.ts    ← 4 MCP resources
 │   └── prompts.ts      ← 4 MCP prompts
 └── index.ts            ← Public API
@@ -81,6 +81,10 @@ organon find --name=frontmatter
 organon verify
 organon verify --gate frontmatter triplets
 
+# Export knowledge graph as JSON
+organon export
+organon export --no-pretty
+
 # Start MCP server
 organon mcp
 ```
@@ -89,7 +93,7 @@ organon mcp
 
 Start with `organon mcp`. Exposes:
 
-**8 Tools:** `organon_validate_frontmatter`, `organon_generate_frontmatter`, `organon_query`, `organon_health`, `organon_find`, `organon_verify_triplets`, `organon_suggest_tools`, `organon_verify`
+**9 Tools:** `organon_validate_frontmatter`, `organon_generate_frontmatter`, `organon_query`, `organon_health`, `organon_find`, `organon_verify_triplets`, `organon_suggest_tools`, `organon_export`, `organon_verify`
 
 **4 Resources:** `organon://index`, `organon://file/{path}`, `organon://scope/{scope}`, `organon://health`
 

--- a/packages/tools/src/cli/commands/export.ts
+++ b/packages/tools/src/cli/commands/export.ts
@@ -1,0 +1,89 @@
+/**
+ * organon export — Export knowledge graph as structured JSON.
+ */
+
+import type { CommandModule } from 'yargs';
+import chalk from 'chalk';
+import { resolveConfig, resolveProjectRoot } from '../../core/config.js';
+import { exportKnowledgeGraph } from '../../core/export.js';
+import { NodeFileSystem } from '../../core/node-fs.js';
+
+interface ExportArgs {
+  'project-root': string;
+  config?: string;
+  pretty: boolean;
+}
+
+export const exportCommand: CommandModule<{}, ExportArgs> = {
+  command: 'export',
+  describe: 'Export organon knowledge graph as structured JSON',
+
+  builder: (yargs) => {
+    return yargs
+      .option('project-root', {
+        describe: 'Project root directory',
+        type: 'string',
+        default: process.cwd(),
+      })
+      .option('config', {
+        describe: 'Path to organon.config.json',
+        type: 'string',
+      })
+      .option('pretty', {
+        describe: 'Pretty-print JSON output',
+        type: 'boolean',
+        default: true,
+      })
+      .example('$0 export', 'Export knowledge graph as JSON')
+      .example('$0 export --no-pretty', 'Export compact JSON (for piping)');
+  },
+
+  handler: async (args) => {
+    const fs = new NodeFileSystem();
+    const projectRoot = await resolveProjectRoot(args['project-root'], fs);
+    const config = await resolveConfig(projectRoot, fs, args.config);
+
+    // Read version: try package.json first, then methodology_version from config
+    let version = '0.0.0';
+    try {
+      const pkgContent = await fs.readFile(`${projectRoot}/package.json`);
+      const pkg = JSON.parse(pkgContent);
+      if (pkg.version) {
+        version = pkg.version;
+      }
+    } catch {
+      // Fall through to config-based version
+    }
+    if (version === '0.0.0') {
+      try {
+        const cfgContent = await fs.readFile(`${projectRoot}/organon.config.json`);
+        const cfg = JSON.parse(cfgContent);
+        if (cfg.methodology_version) {
+          version = cfg.methodology_version;
+        }
+      } catch {
+        // Use default version
+      }
+    }
+
+    const result = await exportKnowledgeGraph({
+      projectRoot,
+      config,
+      fs,
+      version,
+    });
+
+    if (args.pretty) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(JSON.stringify(result));
+    }
+
+    // Summary to stderr so it doesn't pollute JSON output
+    console.error(
+      chalk.dim(
+        `Exported: ${result.entities.length} entities, ${result.assertions.length} assertions, ${result.relationships.length} relationships, ${result.rules.length} rules`,
+      ),
+    );
+  },
+};

--- a/packages/tools/src/cli/commands/query.ts
+++ b/packages/tools/src/cli/commands/query.ts
@@ -18,6 +18,7 @@ interface QueryArgs {
   budget?: number;
   name?: string;
   related?: string;
+  category?: string;
   verbose?: boolean;
 }
 
@@ -67,6 +68,11 @@ export const queryCommand: CommandModule<{}, QueryArgs> = {
         describe: 'Filter by related domain or feature',
         type: 'string',
       })
+      .option('category', {
+        describe: 'Filter by epistemic category',
+        type: 'string',
+        choices: ['constraint', 'assertion', 'rule'],
+      })
       .option('verbose', {
         describe: 'Show full file content',
         type: 'boolean',
@@ -74,7 +80,8 @@ export const queryCommand: CommandModule<{}, QueryArgs> = {
       })
       .example('$0 query --scope=meta', 'List all meta-scope organons')
       .example('$0 query --budget=20000', 'Plan context loading within 20K tokens')
-      .example('$0 query --task=genesis_tool_impl', 'Find organons for a specific task');
+      .example('$0 query --task=genesis_tool_impl', 'Find organons for a specific task')
+      .example('$0 query --category=constraint', 'List all constraint (ETHOS) files');
   },
 
   handler: async (args) => {
@@ -94,6 +101,7 @@ export const queryCommand: CommandModule<{}, QueryArgs> = {
       namePattern: args.name,
       relatedDomain: args.related,
       relatedFeature: args.related,
+      category: args.category as any,
       verbose: args.verbose,
     });
 

--- a/packages/tools/src/cli/index.ts
+++ b/packages/tools/src/cli/index.ts
@@ -14,6 +14,7 @@
  *   coverage       — Invariant coverage analysis
  *   generate-tests — Generate test scaffolds for uncovered invariants
  *   suggest        — Suggest automation tier upgrades
+ *   export         — Export knowledge graph as JSON
  *   release        — Version bump and release
  *   mcp            — Start MCP server
  */
@@ -33,6 +34,7 @@ import { verifyCommand } from './commands/verify.js';
 import { coverageCommand } from './commands/coverage.js';
 import { generateTestsCommand } from './commands/generate-tests.js';
 import { suggestCommand } from './commands/suggest.js';
+import { exportCommand } from './commands/export.js';
 import { releaseCommand } from './commands/release.js';
 import { mcpCommand } from './commands/mcp.js';
 
@@ -51,6 +53,7 @@ async function main() {
     .command(coverageCommand)
     .command(generateTestsCommand)
     .command(suggestCommand)
+    .command(exportCommand)
     .command(releaseCommand)
     .command(mcpCommand)
     .demandCommand(1, chalk.red('Please specify a command'))

--- a/packages/tools/src/core/config.ts
+++ b/packages/tools/src/core/config.ts
@@ -38,6 +38,8 @@ const DEFAULT_ORGANON_GLOBS = [
   '**/PROTOCOLS.md',
   '**/README.md',
   '**/components.md',
+  '**/observations/*.md',
+  '**/rfcs/*.md',
 ];
 
 const DEFAULT_IGNORE_PATTERNS = [

--- a/packages/tools/src/core/export.test.ts
+++ b/packages/tools/src/core/export.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for organon export (knowledge graph).
+ *
+ * @organon-invariant INV-TOOLS-2 every-command-has-tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import { exportKnowledgeGraph } from './export.js';
+import { MemoryFileSystem, makeEthos, makePhilosophy, makeReadme } from './test-helpers.js';
+import type { OrganonConfig } from './types.js';
+
+function makeConfig(projectRoot: string): OrganonConfig {
+  return {
+    projectRoot,
+    organonPaths: ['.', 'organon'],
+    organonGlobs: ['**/ETHOS.md', '**/PHILOSOPHY.md', '**/PROTOCOLS.md', '**/README.md', '**/observations/*.md'],
+    ignorePatterns: [],
+    workflowPaths: {},
+    freshnessThresholdHours: 24,
+  };
+}
+
+const observationContent = `---
+type: rationale
+scope: product
+name: test-observation
+version: "1.0"
+summary: Two review passes is optimal for organon files
+token_estimate: 300
+status: pattern
+created: "2026-02-15"
+---
+
+# Observation 001
+
+Some learning about review passes.
+`;
+
+const ethosWithInvariants = `---
+type: constraints
+scope: domain
+name: tools
+version: "1.0"
+summary: Tools domain constraints
+token_estimate: 500
+invariants_count: 2
+principles_count: 1
+heuristics_count: 1
+invariants:
+  - id: INV-TOOLS-1
+    name: schema-fidelity
+  - id: INV-TOOLS-2
+    name: every-command-tested
+inherits_from:
+  - product
+related_domains:
+  - testing
+---
+
+# tools
+
+## Identity
+
+### What tools IS
+- A CLI
+
+### What tools IS NOT
+- Not a library
+
+## Invariants
+
+1. **Schema fidelity.** All frontmatter validated.
+2. **Every command tested.** All commands have tests.
+
+## Principles (Prioritized)
+
+1. **Fail fast.** Stop on first error.
+
+## Decision Heuristics
+
+| Situation | Action |
+|-----------|--------|
+| New command | Add tests |
+`;
+
+describe('exportKnowledgeGraph', () => {
+  function makeFs() {
+    return new MemoryFileSystem({
+      '/project/organon/domains/tools/ETHOS.md': ethosWithInvariants,
+      '/project/organon/observations/001-test.md': observationContent,
+      '/project/organon/domains/tools/PHILOSOPHY.md': makePhilosophy({ name: 'tools-phil' }),
+      '/project/README.md': makeReadme({ name: 'root', scope: 'product' }),
+    });
+  }
+
+  it('returns structured export with all sections', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    expect(result.version).toBe('0.4.1');
+    expect(result.exported_at).toBeTruthy();
+    expect(result.entities).toBeInstanceOf(Array);
+    expect(result.assertions).toBeInstanceOf(Array);
+    expect(result.relationships).toBeInstanceOf(Array);
+    expect(result.rules).toBeInstanceOf(Array);
+  });
+
+  it('builds entities from parsed files', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    expect(result.entities.length).toBeGreaterThan(0);
+
+    const toolsEntity = result.entities.find((e) => e.name === 'tools');
+    expect(toolsEntity).toBeDefined();
+    expect(toolsEntity!.kind).toBe('organon-file');
+    expect(toolsEntity!.type).toBe('constraints');
+    expect(toolsEntity!.category).toBe('constraint');
+    expect(toolsEntity!.scope).toBe('domain');
+  });
+
+  it('extracts invariants as constraint assertions', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    const invariantAssertions = result.assertions.filter((a) => a.category === 'constraint');
+    expect(invariantAssertions.length).toBe(2);
+    expect(invariantAssertions[0].id).toBe('inv:INV-TOOLS-1');
+    expect(invariantAssertions[0].predicate).toBe('declares_invariant');
+    expect(invariantAssertions[0].content).toBe('schema-fidelity');
+  });
+
+  it('extracts observations as assertion assertions', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    const obsAssertions = result.assertions.filter((a) => a.category === 'assertion');
+    expect(obsAssertions.length).toBe(1);
+    expect(obsAssertions[0].id).toBe('obs:test-observation');
+    expect(obsAssertions[0].predicate).toBe('observed');
+    expect(obsAssertions[0].content).toContain('Two review passes');
+  });
+
+  it('extracts inherits_from relationships', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    const inherits = result.relationships.filter((r) => r.predicate === 'inherits_from');
+    expect(inherits.length).toBeGreaterThan(0);
+    expect(inherits.some((r) => r.target === 'organon:product')).toBe(true);
+  });
+
+  it('extracts related_domains relationships', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    const domainRels = result.relationships.filter((r) => r.predicate === 'related_to_domain');
+    expect(domainRels.length).toBeGreaterThan(0);
+    expect(domainRels.some((r) => r.target === 'domain:testing')).toBe(true);
+  });
+
+  it('extracts verification gates as rules', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    // Built-in gates are registered when verify module loads
+    expect(result.rules.length).toBeGreaterThan(0);
+    expect(result.rules[0].predicate).toBe('validates');
+    expect(result.rules[0].type).toBe('blocking');
+  });
+
+  it('skips files without frontmatter', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/README.md': '# No frontmatter here',
+    });
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    expect(result.entities.length).toBe(0);
+    expect(result.assertions.length).toBe(0);
+  });
+
+  it('uses default version when not provided', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+    });
+
+    expect(result.version).toBe('0.0.0');
+  });
+
+  it('handles unreadable files gracefully', async () => {
+    const fs = makeFs();
+    fs.throwOnRead('ETHOS.md');
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    // Should still return results for readable files
+    expect(result.entities).toBeInstanceOf(Array);
+  });
+
+  it('classifies entities by epistemic category', async () => {
+    const fs = makeFs();
+    const config = makeConfig('/project');
+    const result = await exportKnowledgeGraph({
+      projectRoot: '/project',
+      config,
+      fs,
+      version: '0.4.1',
+    });
+
+    const categories = result.entities.map((e) => e.category);
+    expect(categories).toContain('constraint');
+    expect(categories).toContain('assertion');
+    // PHILOSOPHY and README files have null category
+    expect(categories).toContain(null);
+  });
+});

--- a/packages/tools/src/core/export.ts
+++ b/packages/tools/src/core/export.ts
@@ -1,0 +1,206 @@
+/**
+ * Export organon knowledge graph as structured JSON.
+ *
+ * Produces a snapshot of entities, assertions, relationships, and rules
+ * classified by epistemic category. This is the interoperability surface —
+ * external tools consume this instead of parsing organon files directly.
+ */
+
+import { parseOrganonFile } from './frontmatter-parser.js';
+import { joinPath } from './config.js';
+import { discoverOrganonFiles } from './discover.js';
+import { classifyCategory } from './query.js';
+import { getRegisteredGates } from './verify.js';
+import type {
+  ExportAssertion,
+  ExportEntity,
+  ExportRelationship,
+  ExportResult,
+  ExportRule,
+  FileSystem,
+  OrganonConfig,
+  ParsedOrganonFile,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface ExportOptions {
+  projectRoot: string;
+  config: OrganonConfig;
+  fs: FileSystem;
+  /** Package version to include in export metadata */
+  version?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function exportKnowledgeGraph(options: ExportOptions): Promise<ExportResult> {
+  const { projectRoot, config, fs } = options;
+  const version = options.version ?? '0.0.0';
+
+  // Discover and parse all organon files
+  const allFiles = await discoverOrganonFiles(projectRoot, config, fs);
+  const parsed: ParsedOrganonFile[] = [];
+  for (const file of allFiles) {
+    const absPath = joinPath(projectRoot, file);
+    try {
+      const content = await fs.readFile(absPath);
+      parsed.push(parseOrganonFile(file, content));
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  const withFrontmatter = parsed.filter((f) => f.frontmatter !== null);
+
+  const entities = buildEntities(withFrontmatter);
+  const assertions = buildAssertions(withFrontmatter);
+  const relationships = buildRelationships(withFrontmatter);
+  const rules = buildRules();
+
+  return {
+    version,
+    exported_at: new Date().toISOString(),
+    entities,
+    assertions,
+    relationships,
+    rules,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Entity extraction
+// ---------------------------------------------------------------------------
+
+function fileId(file: ParsedOrganonFile): string {
+  // Strip extension and normalize path
+  const clean = file.path.replace(/\\/g, '/').replace(/\.md$/, '');
+  return `organon:${clean}`;
+}
+
+function buildEntities(files: ParsedOrganonFile[]): ExportEntity[] {
+  return files.map((f) => ({
+    id: fileId(f),
+    kind: 'organon-file',
+    name: f.frontmatter!.name,
+    scope: f.frontmatter!.scope,
+    type: f.frontmatter!.type,
+    category: classifyCategory(f),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Assertion extraction
+// ---------------------------------------------------------------------------
+
+function buildAssertions(files: ParsedOrganonFile[]): ExportAssertion[] {
+  const assertions: ExportAssertion[] = [];
+
+  for (const f of files) {
+    const fm = f.frontmatter!;
+    const category = classifyCategory(f);
+
+    // Extract invariants from ETHOS files as constraints
+    if (fm.type === 'constraints' && fm.invariants) {
+      for (const inv of fm.invariants) {
+        assertions.push({
+          id: `inv:${inv.id}`,
+          category: 'constraint',
+          source: f.path,
+          predicate: 'declares_invariant',
+          content: inv.name,
+        });
+      }
+    }
+
+    // Extract observations as assertions
+    if (category === 'assertion') {
+      assertions.push({
+        id: `obs:${fm.name}`,
+        category: 'assertion',
+        source: f.path,
+        predicate: 'observed',
+        content: fm.summary,
+      });
+    }
+  }
+
+  return assertions;
+}
+
+// ---------------------------------------------------------------------------
+// Relationship extraction
+// ---------------------------------------------------------------------------
+
+function buildRelationships(files: ParsedOrganonFile[]): ExportRelationship[] {
+  const relationships: ExportRelationship[] = [];
+
+  for (const f of files) {
+    const fm = f.frontmatter!;
+    const id = fileId(f);
+
+    // inherits_from
+    if (fm.inherits_from) {
+      for (const parent of fm.inherits_from) {
+        relationships.push({
+          source: id,
+          predicate: 'inherits_from',
+          target: `organon:${parent}`,
+        });
+      }
+    }
+
+    // related_domains
+    if (fm.related_domains) {
+      for (const domain of fm.related_domains) {
+        relationships.push({
+          source: id,
+          predicate: 'related_to_domain',
+          target: `domain:${domain}`,
+        });
+      }
+    }
+
+    // related_features
+    if (fm.related_features) {
+      for (const feature of fm.related_features) {
+        relationships.push({
+          source: id,
+          predicate: 'related_to_feature',
+          target: `feature:${feature}`,
+        });
+      }
+    }
+
+    // primary_rfcs
+    if (fm.primary_rfcs) {
+      for (const rfc of fm.primary_rfcs) {
+        relationships.push({
+          source: id,
+          predicate: 'shaped_by_rfc',
+          target: `rfc:${String(rfc).padStart(3, '0')}`,
+        });
+      }
+    }
+  }
+
+  return relationships;
+}
+
+// ---------------------------------------------------------------------------
+// Rule extraction
+// ---------------------------------------------------------------------------
+
+function buildRules(): ExportRule[] {
+  const gateNames = getRegisteredGates();
+  return gateNames.map((name) => ({
+    id: `gate:${name}`,
+    predicate: 'validates',
+    targets: ['all organon files'],
+    type: 'blocking',
+  }));
+}

--- a/packages/tools/src/core/query.test.ts
+++ b/packages/tools/src/core/query.test.ts
@@ -107,4 +107,81 @@ describe('query', () => {
     const result = await query({ projectRoot: '/project', config, fs, includeInvalid: true });
     expect(result.files.length).toBe(2);
   });
+
+  describe('category filter', () => {
+    const observationContent = `---
+type: rationale
+scope: product
+name: test-observation
+version: "1.0"
+summary: Test observation
+token_estimate: 300
+status: signal
+created: "2026-02-15"
+---
+
+# Observation
+
+Some learning.
+`;
+
+    function makeCategoryFs() {
+      return new MemoryFileSystem({
+        '/project/organon/ETHOS.md': makeEthos({ name: 'root', scope: 'product' }),
+        '/project/organon/domains/genesis/ETHOS.md': makeEthos({ name: 'genesis', scope: 'domain' }),
+        '/project/organon/observations/001-test.md': observationContent,
+        '/project/organon/domains/genesis/PHILOSOPHY.md': makePhilosophy({ name: 'genesis-phil' }),
+        '/project/README.md': makeReadme({ name: 'root', scope: 'product' }),
+      });
+    }
+
+    function makeCategoryConfig(): OrganonConfig {
+      return {
+        projectRoot: '/project',
+        organonPaths: ['.', 'organon'],
+        organonGlobs: ['**/ETHOS.md', '**/PHILOSOPHY.md', '**/PROTOCOLS.md', '**/README.md', '**/observations/*.md'],
+        ignorePatterns: [],
+        workflowPaths: {},
+        freshnessThresholdHours: 24,
+      };
+    }
+
+    it('filters by constraint category (ETHOS files)', async () => {
+      const fs = makeCategoryFs();
+      const config = makeCategoryConfig();
+      const result = await query({ projectRoot: '/project', config, fs, category: 'constraint' });
+      expect(result.files.length).toBe(2);
+      expect(result.files.every((f) => f.frontmatter?.type === 'constraints')).toBe(true);
+    });
+
+    it('filters by assertion category (observation files)', async () => {
+      const fs = makeCategoryFs();
+      const config = makeCategoryConfig();
+      const result = await query({ projectRoot: '/project', config, fs, category: 'assertion' });
+      expect(result.files.length).toBe(1);
+      expect(result.files[0].path).toContain('observations/');
+    });
+
+    it('filters by rule category (procedure files)', async () => {
+      const fs = makeCategoryFs();
+      const config = makeCategoryConfig();
+      const result = await query({ projectRoot: '/project', config, fs, category: 'rule' });
+      // No protocol files in our test fixture
+      expect(result.files.length).toBe(0);
+    });
+
+    it('category filter combines with other filters', async () => {
+      const fs = makeCategoryFs();
+      const config = makeCategoryConfig();
+      const result = await query({
+        projectRoot: '/project',
+        config,
+        fs,
+        category: 'constraint',
+        scope: 'domain',
+      });
+      expect(result.files.length).toBe(1);
+      expect(result.files[0].frontmatter?.name).toBe('genesis');
+    });
+  });
 });

--- a/packages/tools/src/core/query.ts
+++ b/packages/tools/src/core/query.ts
@@ -11,6 +11,7 @@ import { joinPath } from './config.js';
 import { discoverOrganonFiles } from './discover.js';
 import type {
   DiagnosticMessage,
+  EpistemicCategory,
   FileSystem,
   FrontmatterScope,
   FrontmatterType,
@@ -44,6 +45,8 @@ export interface QueryOptions {
   relatedDomain?: string;
   /** Filter by related feature name */
   relatedFeature?: string;
+  /** Filter by epistemic category */
+  category?: EpistemicCategory;
   /** Include files without frontmatter in results */
   includeInvalid?: boolean;
   /** Return full file content (body) or just frontmatter */
@@ -133,6 +136,11 @@ export async function query(options: QueryOptions): Promise<QueryResult> {
     );
   }
 
+  // Filter by epistemic category
+  if (options.category) {
+    filtered = filtered.filter((f) => classifyCategory(f) === options.category);
+  }
+
   // Sort by load_priority (high first), then by token_estimate (smallest first)
   filtered.sort((a, b) => {
     const priorityOrder = { high: 0, medium: 1, low: 2 };
@@ -184,4 +192,22 @@ export async function query(options: QueryOptions): Promise<QueryResult> {
     errors,
     warnings,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Epistemic category classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify an organon file into an epistemic category.
+ *
+ * - constraint: ETHOS.md files (type: constraints)
+ * - assertion: Observation files (type: rationale, path in observations/)
+ * - rule: Protocol files (type: procedures)
+ */
+export function classifyCategory(file: ParsedOrganonFile): EpistemicCategory | null {
+  if (file.frontmatter?.type === 'constraints') return 'constraint';
+  if (file.frontmatter?.type === 'rationale' && file.path.includes('observations/')) return 'assertion';
+  if (file.frontmatter?.type === 'procedures') return 'rule';
+  return null;
 }

--- a/packages/tools/src/core/types.ts
+++ b/packages/tools/src/core/types.ts
@@ -61,6 +61,7 @@ export type AutomationTier = 'automated' | 'semi-automated' | 'manual';
 export type LoadPriority = 'high' | 'medium' | 'low';
 export type Complexity = 'high' | 'medium' | 'low';
 export type Audience = 'llm' | 'human' | 'tooling';
+export type EpistemicCategory = 'constraint' | 'assertion' | 'rule';
 
 export interface ProtocolEntry {
   id: string;
@@ -284,6 +285,49 @@ export interface ToolSuggestion {
   reason: string;
   steps: number;
   complexity: Complexity;
+}
+
+// ---------------------------------------------------------------------------
+// Export types
+// ---------------------------------------------------------------------------
+
+export interface ExportEntity {
+  id: string;
+  kind: string;
+  name: string;
+  scope: string;
+  type: string;
+  category: EpistemicCategory | null;
+}
+
+export interface ExportAssertion {
+  id: string;
+  category: EpistemicCategory;
+  source: string;
+  predicate: string;
+  content: string;
+}
+
+export interface ExportRelationship {
+  source: string;
+  predicate: string;
+  target: string;
+}
+
+export interface ExportRule {
+  id: string;
+  predicate: string;
+  targets: string[];
+  type: string;
+}
+
+export interface ExportResult {
+  version: string;
+  exported_at: string;
+  entities: ExportEntity[];
+  assertions: ExportAssertion[];
+  relationships: ExportRelationship[];
+  rules: ExportRule[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/tools/src/mcp/tools.ts
+++ b/packages/tools/src/mcp/tools.ts
@@ -13,6 +13,7 @@ import { find } from '../core/find.js';
 import { verifyTriplets } from '../core/verify-triplets.js';
 import { suggestTools } from '../core/suggest-tools.js';
 import { verify } from '../core/verify.js';
+import { exportKnowledgeGraph } from '../core/export.js';
 
 export function registerTools(
   server: McpServer,
@@ -71,7 +72,7 @@ export function registerTools(
   // 3. Query
   server.tool(
     'organon_query',
-    'Query organon files by metadata (scope, type, priority, task, budget, name)',
+    'Query organon files by metadata (scope, type, priority, task, budget, name, category)',
     {
       scope: z.enum(['product', 'domain', 'feature', 'component', 'meta', 'methodology']).optional(),
       type: z.enum(['navigation', 'constraints', 'rationale', 'procedures', 'mapping']).optional(),
@@ -80,6 +81,7 @@ export function registerTools(
       budget: z.number().optional().describe('Maximum total token budget'),
       name: z.string().optional().describe('Filter by name (substring)'),
       related: z.string().optional().describe('Filter by related domain or feature'),
+      category: z.enum(['constraint', 'assertion', 'rule']).optional().describe('Filter by epistemic category'),
       verbose: z.boolean().optional().describe('Include full file content'),
     },
     async (args) => {
@@ -95,6 +97,7 @@ export function registerTools(
         namePattern: args.name,
         relatedDomain: args.related,
         relatedFeature: args.related,
+        category: args.category,
         verbose: args.verbose,
       });
       return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
@@ -165,7 +168,25 @@ export function registerTools(
     },
   );
 
-  // 8. Verify (orchestrator)
+  // 8. Export knowledge graph
+  server.tool(
+    'organon_export',
+    'Export organon knowledge graph as structured JSON (entities, assertions, relationships, rules)',
+    {
+      version: z.string().optional().describe('Version to include in export metadata'),
+    },
+    async (args) => {
+      const result = await exportKnowledgeGraph({
+        projectRoot,
+        config,
+        fs,
+        version: args.version,
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // 9. Verify (orchestrator)
   server.tool(
     'organon_verify',
     'Run verification gates (frontmatter, triplets, freshness — or custom subset)',

--- a/packages/tools/src/templates/config.ts
+++ b/packages/tools/src/templates/config.ts
@@ -13,7 +13,9 @@ export const CONFIG_TEMPLATE = `{
     "**/README.md",
     "**/PRIMER.md",
     "**/methodology-reference.md",
-    "**/components.md"
+    "**/components.md",
+    "**/observations/*.md",
+    "**/rfcs/*.md"
   ],
   "ignorePatterns": [
     "**/node_modules/**",

--- a/rfcs/009-epistemic-model.md
+++ b/rfcs/009-epistemic-model.md
@@ -1,0 +1,172 @@
+---
+type: rationale
+scope: product
+name: epistemic-model
+version: "1.0"
+status: implementing
+summary: Formalize organon's implicit epistemic categories (constraint/assertion/rule) and add knowledge export for interoperability
+token_estimate: 2200
+author: Claude Opus 4.6
+created: "2026-02-15"
+primary_rfcs: []
+secondary_rfcs: [1, 5]
+audience: [llm, human, tooling]
+---
+
+# RFC 009: Epistemic Model & Knowledge Interoperability
+
+> Formalize the implicit epistemology in organon files so external knowledge systems can interoperate without coupling to file structure.
+
+---
+
+## Problem Statement
+
+Organon already models three epistemic categories implicitly:
+
+- **ETHOS invariants** = Constraints (what should be true)
+- **Observations** = Assertions (what is empirically observed)
+- **Verification gates** = Rules (what must hold, checked automatically)
+
+This maps directly to knowledge systems like axiom-db's fact/should/rule separation. But the methodology doesn't formally recognize this — the type system uses artifact types (`constraints`/`rationale`/`procedures`), not epistemic categories.
+
+**Current state:** Organon data is locked in file structure. External tools must parse frontmatter YAML and directory conventions to extract knowledge.
+
+**Desired state:** A formal epistemic model documented in the methodology, plus a structured export format that any knowledge system can consume.
+
+---
+
+## Proposed Solution
+
+### 1. Formalize three epistemic categories
+
+| Category | Definition | Maps to | Example |
+|----------|-----------|---------|---------|
+| **Constraint** | What should be true — normative declarations | ETHOS.md invariants | "Cache TTL max 24h" |
+| **Assertion** | What is empirically observed — descriptive claims | Observation files | "Two review passes is optimal" |
+| **Rule** | What must hold, checked automatically — enforcement logic | Verification gates, protocols | "Frontmatter counts match content" |
+
+These are not new artifact types — they are an epistemic lens on existing artifacts.
+
+### 2. Add `organon query --category` filter
+
+Map the category filter to existing frontmatter:
+
+| Category | Filter logic |
+|----------|-------------|
+| `constraint` | `type === 'constraints'` |
+| `assertion` | `type === 'rationale'` AND path contains `observations/` |
+| `rule` | `type === 'procedures'` |
+
+### 3. Add `organon export` command
+
+Produce a structured JSON knowledge graph:
+
+```json
+{
+  "version": "0.4.1",
+  "exported_at": "2026-02-15T...",
+  "entities": [...],
+  "assertions": [...],
+  "relationships": [...],
+  "rules": [...]
+}
+```
+
+This is the interoperability surface. External tools consume export output instead of parsing organon files directly.
+
+### 4. Add observation `status` lifecycle field
+
+```yaml
+status: signal | pattern | actionable | resolved
+```
+
+Purely additive — existing observations without `status` remain valid.
+
+---
+
+## Organon Impact
+
+### Update
+
+- `book-llms/three-layer-architecture.md` — Add `## Epistemic Categories` section after enforcement loop
+- `book-llms/frontmatter-system.md` — Document observation `status` field and export format
+- `packages/tools/src/core/types.ts` — Add `EpistemicCategory` type, `ExportResult` interface, observation status
+- `packages/tools/src/core/query.ts` — Add `category` filter
+- `packages/tools/src/cli/commands/query.ts` — Add `--category` flag
+- `packages/tools/src/mcp/tools.ts` — Add `category` param to `organon_query`, add `organon_export` tool
+
+### Create
+
+- `rfcs/009-epistemic-model.md` — This RFC
+- `packages/tools/src/core/export.ts` — Export logic
+- `packages/tools/src/core/export.test.ts` — Export tests
+- `packages/tools/src/cli/commands/export.ts` — CLI command
+
+---
+
+## Technical Implementation
+
+### `organon query --category`
+
+One new filter block in the existing query pipeline. The `category` filter is applied after standard filters (scope, type, priority) and before sorting:
+
+```typescript
+if (options.category) {
+  filtered = filtered.filter((f) => classifyCategory(f) === options.category);
+}
+```
+
+Classification function:
+
+```typescript
+function classifyCategory(file: ParsedOrganonFile): EpistemicCategory | null {
+  if (file.frontmatter?.type === 'constraints') return 'constraint';
+  if (file.frontmatter?.type === 'rationale' && file.path.includes('observations/')) return 'assertion';
+  if (file.frontmatter?.type === 'procedures') return 'rule';
+  return null;
+}
+```
+
+### `organon export`
+
+Reuses existing infrastructure:
+- `discoverOrganonFiles()` for file discovery
+- `parseFrontmatter()` for metadata extraction
+- Gate metadata from verify config for rules
+
+Output sections:
+- **entities**: One per organon file (id, kind, name, scope, type, category)
+- **assertions**: Extracted from ETHOS invariants (constraints) and observation content (assertions)
+- **relationships**: `inherits_from`, `loads`, `related_domains` from frontmatter
+- **rules**: Verification gates with their targets
+
+---
+
+## What We Did NOT Do
+
+- No new artifact types — epistemic categories are a lens, not a new type system
+- No semantic search or embeddings — that's external tool territory
+- No knowledge database — organon stays file-based; export is the interop surface
+- No axiom-db integration code — axiom-db consumes the export format independently
+- No observation management CLI (`organon observe`) — future RFC if status field proves useful
+
+---
+
+## Success Metrics
+
+1. `organon query --category constraint` returns only ETHOS.md files
+2. `organon query --category assertion` returns only observation files
+3. `organon export` produces valid JSON with all four sections populated
+4. All existing tests continue to pass (backward compatible)
+5. New tests cover category filter and export logic
+
+---
+
+## Related Files
+
+| File | Relationship |
+|------|-------------|
+| [001-testing-framework.md](./001-testing-framework.md) | Established tier-4 testing; export makes invariant data portable |
+| [005-observation-synthesis-loop.md](./005-observation-synthesis-loop.md) | Established observations; this RFC adds lifecycle tracking |
+| [../book-llms/three-layer-architecture.md](../book-llms/three-layer-architecture.md) | Updated with epistemic categories section |
+| [../book-llms/frontmatter-system.md](../book-llms/frontmatter-system.md) | Updated with observation status field |

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -52,6 +52,7 @@ See [book-llms/patterns.md](../book-llms/patterns.md#rfc-driven-evolution-patter
 | [006](./006-init-and-upgrade.md) | Init, Upgrade, and Skills as First-Class Citizens | Implemented | Claude Opus 4.6 | 2026-02-12 |
 | [007](./007-v040-release.md) | v0.4.0 — Init/Verify Polish, New Gates, CLI Ergonomics | Implementing | Claude Opus 4.6 | 2026-02-13 |
 | [008](./008-scala-testing-library.md) | Scala 3 Testing Library & Multi-Language Package Strategy | Implemented | Claude Opus 4.6 | 2026-02-14 |
+| [009](./009-epistemic-model.md) | Epistemic Model & Knowledge Interoperability | Implementing | Claude Opus 4.6 | 2026-02-15 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Implement RFC 009: formalize organon's implicit epistemic categories (constraint/assertion/rule) and add structured JSON export for knowledge system interoperability
- New `organon export` command (14th CLI) produces a knowledge graph with entities, assertions, relationships, and rules
- New `organon query --category` filter lets agents query by epistemic category instead of artifact type
- New `organon_export` MCP tool (9th tool) for IDE integration
- Observation `status` lifecycle field (`signal | pattern | actionable | resolved`) added to frontmatter spec

### Files changed (23)

**New (5):** RFC document, export core + tests + CLI, observation 005
**Methodology (4):** three-layer-architecture.md, frontmatter-system.md, templates.md, patterns.md
**Tooling (7):** types.ts, query.ts + tests, query CLI, index.ts, MCP tools, config.ts
**Docs (5):** README.md, packages/tools/README.md, rfcs/README.md, tools ETHOS.md, CLI reference
**Config (2):** organon.config.json, observations/README.md

## Test plan

- [x] `npm run build` — compiles without errors
- [x] `npm test` — 275 tests pass (11 new export tests, 4 new category filter tests)
- [x] `organon verify` — all 9 gates pass
- [x] `organon query --category constraint` — returns 4 ETHOS files
- [x] `organon query --category assertion` — returns 4 observation files
- [x] `organon export` — produces valid JSON (18 entities, 34 assertions, 7 relationships, 9 rules)
- [x] `/methodology-spec-evolution` — cross-file consistency verified
- [x] `/session-compounding` — session learnings captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)