### PR TITLE
fix: Scala testing issues #8, #9, #10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fix `FRONTMATTER_NAME_DIR_MISMATCH` false positives for files in collection/container directories (`organon/`, `observations/`, `rfcs/`, `book-llms/`, `protocols/`, `book-humans/`) — closes #11, #2
+- `assertExportsPresent` now detects Scala 3 enum case members (`case Foo, Bar`) — closes #8
+- Rename `AssertionError` → `OrganonAssertionError` to avoid shadowing `java.lang.AssertionError` — closes #9
+- `tier4-tests` gate now recognizes Scala Maven import path (`io.github.vledicfranco.organon.testing`) — closes #10
 
 ## [0.5.1] - 2026-02-16
 

--- a/book-llms/invariant-tracking.md
+++ b/book-llms/invariant-tracking.md
@@ -221,11 +221,11 @@ Two language-specific implementations of tier-4 testing are available:
 
 **TypeScript** (`@organon-methodology/testing`):
 - **Source:** `packages/testing/` | **RFC:** [001-testing-framework](../rfcs/001-testing-framework.md)
-- Vitest adapter, 7 assertions, 206 tests
+- Vitest adapter, 7 assertions, 285 tests
 
 **Scala 3** (`io.github.vledicfranco:organon-testing_3`):
 - **Source:** `packages/testing-scala/` | **RFC:** [008-scala-testing-library](../rfcs/008-scala-testing-library.md)
-- MUnit + ScalaTest adapters, 6 assertions, 71 tests
+- MUnit + ScalaTest adapters, 6 assertions, 75 tests
 
 Both implementations provide:
 - **`testInvariant(id, description, fn)`** — wrapper that links test execution to invariant IDs

--- a/organon/domains/testing/README.md
+++ b/organon/domains/testing/README.md
@@ -22,7 +22,7 @@ audience: [llm, human]
 - [001-testing-framework](../../../rfcs/001-testing-framework.md) (Implemented)
 - [008-scala-testing-library](../../../rfcs/008-scala-testing-library.md) (Implemented)
 
-**Implementation:** Multi-language — TypeScript (7 assertions, 206 tests) and Scala 3 (6 assertions, 71 tests)
+**Implementation:** Multi-language — TypeScript (7 assertions, 285 tests) and Scala 3 (6 assertions, 75 tests)
 
 ---
 

--- a/packages/testing-scala/src/main/scala/io/github/vledicfranco/organon/testing/Assertions.scala
+++ b/packages/testing-scala/src/main/scala/io/github/vledicfranco/organon/testing/Assertions.scala
@@ -238,6 +238,9 @@ object Assertions:
 
   private val ExportListPattern = raw"""export\s*\{([^}]+)\}""".r
 
+  /** Scala 3 enum case members: `case Foo` or `case Foo, Bar, Baz` */
+  private val EnumCasePattern = raw"""^\s*case\s+([A-Z]\w+(?:\s*,\s*[A-Z]\w+)*)""".r
+
   /** Extract all exported/public names from file content (pure function, no I/O). */
   def extractExportNames(content: String): Seq[String] =
     val names = Vector.newBuilder[String]
@@ -267,5 +270,12 @@ object Assertions:
                 val nameOnly = trimmed.split(raw"""\s""")(0)
                 if nameOnly.nonEmpty then names += nameOnly
       }
+
+      // Scala 3 enum case members (exclude match arms which contain =>)
+      if !line.contains("=>") then
+        EnumCasePattern.findFirstMatchIn(line).foreach { m =>
+          val caseNames = m.group(1).split(",").map(_.trim).filter(_.nonEmpty)
+          names ++= caseNames
+        }
 
     names.result().toSeq

--- a/packages/testing-scala/src/main/scala/io/github/vledicfranco/organon/testing/errors.scala
+++ b/packages/testing-scala/src/main/scala/io/github/vledicfranco/organon/testing/errors.scala
@@ -81,7 +81,7 @@ case class ExportsPresentResolverError(message0: String)
 // Assertion errors (logical violations after successful resolution)
 // ---------------------------------------------------------------------------
 
-sealed trait AssertionError extends RuntimeException:
+sealed trait OrganonAssertionError extends RuntimeException:
   def violations: Seq[Any]
 
 case class MaxValueAssertionError(violations: Seq[MaxValueViolation])
@@ -94,14 +94,14 @@ case class MaxValueAssertionError(violations: Seq[MaxValueViolation])
         .mkString("\n")
       s"Max value assertion failed: ${violations.length} violation(s) found\n$details"
     })
-    with AssertionError
+    with OrganonAssertionError
 
 case class FileExistsAssertionError(violations: Seq[FileExistsViolation])
     extends RuntimeException({
       val details = violations.map(v => s"  ${v.file}").mkString("\n")
       s"File exists assertion failed: ${violations.length} missing file(s)\n$details"
     })
-    with AssertionError
+    with OrganonAssertionError
 
 case class NoSideEffectsAssertionError(violations: Seq[NoSideEffectsViolation])
     extends RuntimeException({
@@ -110,7 +110,7 @@ case class NoSideEffectsAssertionError(violations: Seq[NoSideEffectsViolation])
         .mkString("\n")
       s"No side effects assertion failed: ${violations.length} forbidden import(s) found\n$details"
     })
-    with AssertionError
+    with OrganonAssertionError
 
 case class NamingConventionAssertionError(violations: Seq[NamingConventionViolation])
     extends RuntimeException({
@@ -122,14 +122,14 @@ case class NamingConventionAssertionError(violations: Seq[NamingConventionViolat
         .mkString("\n")
       s"Naming convention assertion failed: ${violations.length} violation(s) found\n$details"
     })
-    with AssertionError
+    with OrganonAssertionError
 
 case class ExportsPresentAssertionError(violations: Seq[ExportsPresentViolation])
     extends RuntimeException({
       val details = violations.map(v => s"  ${v.file} — missing export \"${v.name}\"").mkString("\n")
       s"Exports present assertion failed: ${violations.length} missing export(s)\n$details"
     })
-    with AssertionError
+    with OrganonAssertionError
 
 // ---------------------------------------------------------------------------
 // Custom assertion error

--- a/packages/testing-scala/src/test/scala/io/github/vledicfranco/organon/testing/adapters/ScalaTestAdapterSpec.scala
+++ b/packages/testing-scala/src/test/scala/io/github/vledicfranco/organon/testing/adapters/ScalaTestAdapterSpec.scala
@@ -10,6 +10,7 @@ class ScalaTestAdapterSpec extends OrganonFlatSpec:
   override protected def fileSystem: FileSystem = TestFileSystem(Map(
     "src/config.scala" -> "val ttl = 100\nval timeout = 50",
     "src/core/TypeSystem.scala" -> "package io.constellation\n\ntrait CType\ntrait CValue\nenum CTypeTag",
+    "src/core/Color.scala" -> "package io.constellation\n\nenum Color:\n  case Red, Green, Blue",
   ))(using ExecutionContext.global)
 
   testInvariant("INV-TEST-ADAPTER-1", "ScalaTest adapter registers and runs tests"):
@@ -41,4 +42,10 @@ class ScalaTestAdapterSpec extends OrganonFlatSpec:
     Assertions.assertExportsPresent(ExportsPresentOptions(
       file = "src/core/TypeSystem.scala",
       expectedExports = Seq("CType", "CValue", "CTypeTag")
+    ))
+
+  testInvariant("INV-TEST-ADAPTER-6", "ScalaTest adapter detects enum case members"):
+    Assertions.assertExportsPresent(ExportsPresentOptions(
+      file = "src/core/Color.scala",
+      expectedExports = Seq("Color", "Red", "Green", "Blue")
     ))

--- a/packages/testing-scala/src/test/scala/io/github/vledicfranco/organon/testing/assertions/ExportsPresentValidatorSpec.scala
+++ b/packages/testing-scala/src/test/scala/io/github/vledicfranco/organon/testing/assertions/ExportsPresentValidatorSpec.scala
@@ -48,3 +48,25 @@ class ExportsPresentValidatorSpec extends munit.FunSuite:
       )
     assert(ex.getMessage.contains("src/main.scala"))
     assert(ex.getMessage.contains("myFunc"))
+
+  // --- extractExportNames: enum case detection (#8) ---
+
+  test("extractExportNames detects enum case members"):
+    val content = "enum Color:\n  case Red, Green, Blue"
+    val names = Assertions.extractExportNames(content)
+    assert(names.contains("Color"))
+    assert(names.contains("Red"))
+    assert(names.contains("Green"))
+    assert(names.contains("Blue"))
+
+  test("extractExportNames does not extract match arm cases"):
+    val content = "x match\n  case Foo => doThing()\n  case bar => other()"
+    val names = Assertions.extractExportNames(content)
+    assert(!names.contains("Foo"))
+    assert(!names.contains("bar"))
+
+  test("extractExportNames handles single enum case"):
+    val content = "enum Status:\n  case Active"
+    val names = Assertions.extractExportNames(content)
+    assert(names.contains("Status"))
+    assert(names.contains("Active"))

--- a/packages/tools/src/core/verify-tier4-tests.test.ts
+++ b/packages/tools/src/core/verify-tier4-tests.test.ts
@@ -141,6 +141,50 @@ describe('verifyTier4Tests', () => {
     expect(result.warnings.length).toBeGreaterThan(0);
   });
 
+  it('passes when Scala file has organon testing import and testInvariant', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/tests/MySpec.scala': [
+        `// @organon-invariant INV-FOO-1`,
+        `import io.github.vledicfranco.organon.testing.adapters.OrganonSuite`,
+        `testInvariant("INV-FOO-1", "test") {`,
+        `  Future.successful(assert(true))`,
+        `}`,
+      ].join('\n'),
+    });
+
+    const result = await verifyTier4Tests({
+      projectRoot: PROJECT_ROOT,
+      config: makeConfig({ testGlobs: ['**/*Spec.scala'] }),
+      fs,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.annotatedFiles).toBe(1);
+    expect(result.validFiles).toBe(1);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('warns Scala file with annotation but no organon import with Scala suggestion', async () => {
+    const fs = new MemoryFileSystem({
+      '/project/tests/MySpec.scala': [
+        `// @organon-invariant INV-FOO-1`,
+        `import munit.FunSuite`,
+        `testInvariant("INV-FOO-1", "test") {}`,
+      ].join('\n'),
+    });
+
+    const result = await verifyTier4Tests({
+      projectRoot: PROJECT_ROOT,
+      config: makeConfig({ testGlobs: ['**/*Spec.scala'] }),
+      fs,
+    });
+
+    expect(result.success).toBe(true);
+    const importWarning = result.warnings.find((w) => w.code === 'TIER4_MISSING_IMPORT');
+    expect(importWarning).toBeDefined();
+    expect(importWarning!.suggestion).toContain('OrganonSuite');
+  });
+
   it('reports warning suggestions with correct import path', async () => {
     const fs = new MemoryFileSystem({
       '/project/tests/my.test.ts': [

--- a/packages/tools/src/core/verify-tier4-tests.ts
+++ b/packages/tools/src/core/verify-tier4-tests.ts
@@ -45,10 +45,12 @@ const DEFAULT_TEST_GLOBS = [
   '**/*.test.jsx',
   '**/*.spec.ts',
   '**/*.spec.js',
+  '**/*Spec.scala',
+  '**/*Test.scala',
 ];
 
 const ANNOTATION_RE = /@organon-invariant\s+INV-[\w-]+/;
-const TESTING_IMPORT_RE = /from\s+['"]@organon-methodology\/testing/;
+const TESTING_IMPORT_RE = /from\s+['"]@organon-methodology\/testing|import\s+io\.github\.vledicfranco\.organon\.testing\./;
 const TEST_INVARIANT_RE = /testInvariant\s*\(/;
 
 // ---------------------------------------------------------------------------
@@ -94,12 +96,16 @@ export async function verifyTier4Tests(options: {
 
       // Check for @organon-methodology/testing import
       if (!TESTING_IMPORT_RE.test(content)) {
+        const isScala = file.endsWith('.scala');
+        const suggestion = isScala
+          ? `Add: import io.github.vledicfranco.organon.testing.adapters.OrganonSuite`
+          : `Add: import { testInvariant } from '@organon-methodology/testing/vitest';`;
         warnings.push({
           severity: 'warning',
           code: 'TIER4_MISSING_IMPORT',
           message: `Test file has @organon-invariant annotation but does not import from @organon-methodology/testing`,
           file,
-          suggestion: `Add: import { testInvariant } from '@organon-methodology/testing/vitest';`,
+          suggestion,
         });
         isValid = false;
       }

--- a/rfcs/008-scala-testing-library.md
+++ b/rfcs/008-scala-testing-library.md
@@ -60,7 +60,7 @@ The `@organon-methodology/testing` TypeScript library provides semantic invarian
 
 - **17 main source files:** FileSystem, errors, 6 resolvers, 5 validators, Assertions, InvariantTest, InvariantTestRegistry, MUnitAdapter
 - **10 test files:** TestFileSystem (in-memory mock), 5 validator specs, 2 resolver specs, InvariantTestSpec, MUnitAdapterSpec
-- **66 tests passing** across all modules
+- **75 tests passing** across all modules
 - **Build:** sbt 1.10.7, Scala 3.3.4, os-lib 0.11.4, MUnit 1.1.0
 - **CI:** GitHub Actions job for Scala tests (separate from Node.js job)
 - **Publishing:** sbt-ci-release to Maven Central via `io.github.vledicfranco` namespace


### PR DESCRIPTION
## Summary

- **#8**: `assertExportsPresent` now detects Scala 3 `enum case` members (`case Foo, Bar, Baz`) via new `EnumCasePattern` regex with match-arm exclusion (`=>` check)
- **#9**: Rename `AssertionError` sealed trait → `OrganonAssertionError` to avoid shadowing `java.lang.AssertionError` on wildcard import
- **#10**: `tier4-tests` gate now recognizes Scala Maven import path (`io.github.vledicfranco.organon.testing`), adds `*Spec.scala`/`*Test.scala` to default test globs, and provides language-aware import suggestions

## Test plan

- [x] Scala tests: 75/75 pass (6 new — 3 extraction unit tests, 1 adapter integration test, 2 pre-existing)
- [x] TypeScript tests: 285/285 pass (2 new Scala tier4 test cases)
- [x] `organon verify`: all 9 gates pass
- [x] No regressions in existing test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)